### PR TITLE
Update xlOper.h

### DIFF
--- a/xlCpp/cppFiles/xlOper.h
+++ b/xlCpp/cppFiles/xlOper.h
@@ -9,8 +9,6 @@
 #include <string>
 using namespace std;
 
-#include "matrix.h"
-
 //  Additional / alternative functions to the ones in framework.h
 
 LPXLOPER12 TempXLOPER12()


### PR DESCRIPTION
Removed spurious include preventing the Excel interface to work without a matrix.h file.