### PR TITLE
FIX: mark point error when across the last block

### DIFF
--- a/blocklist.h
+++ b/blocklist.h
@@ -196,7 +196,10 @@ public:
     void setmark()
     {
         marked_block = cur_block;
-        marked_space = next_space;
+        if (next_space == cur_block->begin())
+            marked_space = next_space;
+        else
+            marked_space = std::prev(next_space);
     }
 
     //  Rewind to mark


### PR DESCRIPTION
Such codes change will make the `mark` function work correctly under single nodes mode (`multi` equals `false`). I am not sure it will work smoothly in the multi mode.